### PR TITLE
project does not build due to pom errors. this commit fixes the probl…

### DIFF
--- a/simple-security/client-javascript/pom.xml
+++ b/simple-security/client-javascript/pom.xml
@@ -13,7 +13,6 @@
 
     <artifactId>simple-security-client-javascript</artifactId>
 
-    <packaging>war</packaging>
 
     <build>
         <plugins>

--- a/todo-list/client-polymer/pom.xml
+++ b/todo-list/client-polymer/pom.xml
@@ -47,8 +47,11 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.7.RC0</version>
+                <version>9.4.11.v20180605</version>
                 <configuration>
+                    <supportedPackagings>
+                        <supportedPackaging>jar</supportedPackaging>
+                    </supportedPackagings>
                     <webAppSourceDirectory>${project.basedir}/</webAppSourceDirectory>
                     <httpConnector>
                         <port>8082</port>


### PR DESCRIPTION
…ems:

wrong packaging (war)

simple-security-client-javascript aus: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-war-plugin:2.2:war (default-war) on project simple-security-client-javascript: Error assembling WAR: webxml attribute is required (or pre-existing WEB-INF/web.xml if executing in update mode) -> [Help 1] 

can be solved by changing packing (remove war):

Also todo-list fails due to jetty mvn plugin updates (https://github.com/eclipse/jetty.project/issues/2372), can be fixed by:

           <configuration>
              <supportedPackagings>
                <supportedPackaging>jar</supportedPackaging>
              </supportedPackagings>
            </configuration>